### PR TITLE
update index-embeddings 0.1.2 -> 0.1.3 and dockerfile chmod +x use_mo…

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -19,6 +19,8 @@ COPY . .
 
 COPY ./ragdir /ragdir
 
+RUN chmod +x use_model.sh
+
 ENTRYPOINT ["sh", "-c", "./use_model.sh && gunicorn app:app"]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 llama-index==0.10.26
 llama-index-llms-ollama==0.1.2
-llama-index-embeddings-ollama==0.1.2
+llama-index-embeddings-ollama==0.1.3
 Flask==3.0.3
 Werkzeug==3.0.3
 redis==5.0.4


### PR DESCRIPTION
update version of llama-index-embeddings-ollama from 0.1.2 to 0.1.2 to fix #6 and make use_model.sh executable in dockerfile